### PR TITLE
add get all centers endpoint

### DIFF
--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -54,6 +54,29 @@ class CenterController extends ModelService {
             })            
         }
     }
+
+    /**
+     * @description Gets all event centers
+     * @method getCenters
+     * @static
+     * @memberof CenterController
+     * @returns {function} A middleware function that handles the GET request
+     */
+    static getCenters()
+    {
+        return (req, res) => {
+            return this.findAllModelObjects(Center, {
+                where: { userId: req.body.user.userId },
+                order: [['name', 'ASC']]
+            })
+            .then((centers) => {
+                this.successResponse(res, {centers: centers});
+            })
+            .catch(error => {
+                this.errorResponse(res, error);
+            })
+        }
+    }
 }
 
 export default CenterController;

--- a/server/routes/centerRoutes.js
+++ b/server/routes/centerRoutes.js
@@ -12,7 +12,8 @@ centerRouter.route('/api/v1/centers')
     UserController.checkPrivilege())
 .post(CenterValidations.validateCenter(),
     CenterValidations.ifExistCenter(),
-    CenterController.createCenter());
+    CenterController.createCenter())
+.get(CenterController.getCenters())
 
 centerRouter.route('/api/v1/centers/:centerId')
 .all(UserController.validateUserAccess(),
@@ -20,6 +21,6 @@ centerRouter.route('/api/v1/centers/:centerId')
 .put(CenterValidations.validateCenter(),
     CenterValidations.ifExistCenter(),
     CenterController.updateCenter())
-.get()
+
 
 export default centerRouter;


### PR DESCRIPTION
## What does this PR do?

Add functionality for an admin to get all event centers

## Description of Task to be completed?

Have the following endpoint working
- GET: /api/v1/centers

## How should this be manually tested?
Cloning the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route
### Required fields
N/A

## What are the relevant pivotal tracker stories?
#152800498

## Sample screenshot
![get-centers](https://user-images.githubusercontent.com/29798373/33079333-a27c9216-ced5-11e7-8c36-f224d4b6c817.png)
