### PR TITLE
add pagination to get all centers

### DIFF
--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -77,6 +77,30 @@ class CenterController extends ModelService {
             })
         }
     }
+
+    /**
+     * @description Gets all event centers
+     * @method getCenters
+     * @static
+     * @memberof CenterController
+     * @returns {function} A middleware function that handles the GET request
+     */
+    static getCenters()
+    {
+        return (req, res) => {
+            return this.findAllModelObjects(Center, {
+                order: [['name', 'ASC']],
+                offset: req.query.page || 0,
+                limit: 10
+            })
+            .then((centers) => {
+                this.successResponse(res, {centers: centers});
+            })
+            .catch(error => {
+                this.errorResponse(res, error);
+            })
+        }
+    }
 }
 
 export default CenterController;

--- a/server/routes/centerRoutes.js
+++ b/server/routes/centerRoutes.js
@@ -8,17 +8,17 @@ const { CenterController, UserController } = controllers,
       centerRouter = express.Router();
 
 centerRouter.route('/api/v1/centers')
-.all(UserController.validateUserAccess(),
-    UserController.checkPrivilege())
-.post(CenterValidations.validateCenter(),
+.all(UserController.validateUserAccess())
+.post(UserController.checkPrivilege(),
+    CenterValidations.validateCenter(),
     CenterValidations.ifExistCenter(),
     CenterController.createCenter())
 .get(CenterController.getCenters())
 
 centerRouter.route('/api/v1/centers/:centerId')
-.all(UserController.validateUserAccess(),
-    UserController.checkPrivilege())
-.put(CenterValidations.validateCenter(),
+.all(UserController.validateUserAccess())
+.put(UserController.checkPrivilege(),
+    CenterValidations.validateCenter(),
     CenterValidations.ifExistCenter(),
     CenterController.updateCenter())
 


### PR DESCRIPTION
## What does this PR do?
Add pagination to get all centers route

## Description of Task to be completed?
Have the following endpoint working
- GET /api/v1/centers?page=page_number

## How should this be manually tested?
Cloning the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route
### Required fields
N/A

## What are the relevant pivotal tracker stories?
#153065175