### PR TITLE
add get a single center endpoint

### DIFF
--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -77,6 +77,28 @@ class CenterController extends ModelService {
             })
         }
     }
+
+    /**
+     * @description Gets a single event center
+     * @method getCenter
+     * @static
+     * @memberof CenterController
+     * @returns {function} A middleware function that handles the GET request
+     */
+    static getCenter()
+    {
+        return (req, res) => {
+            return this.findAllModelObjects(Center, {
+                where: { centerId: req.params.centerId }
+            })
+            .then((center) => {
+                this.successResponse(res, {center: center});
+            })
+            .catch(error => {
+                this.errorResponse(res, error);
+            })
+        }
+    }
 }
 
 export default CenterController;

--- a/server/routes/centerRoutes.js
+++ b/server/routes/centerRoutes.js
@@ -4,6 +4,7 @@ import services from '../services';
 import validations from '../validations';
 
 const { CenterController, UserController } = controllers,
+      { ValidationService } = services,
       { CenterValidations } = validations,
       centerRouter = express.Router();
 
@@ -16,11 +17,14 @@ centerRouter.route('/api/v1/centers')
 .get(CenterController.getCenters())
 
 centerRouter.route('/api/v1/centers/:centerId')
-.all(UserController.validateUserAccess(),
-    UserController.checkPrivilege())
-.put(CenterValidations.validateCenter(),
+.put(UserController.validateUserAccess(),
+    UserController.checkPrivilege(),
+    CenterValidations.validateCenter(),
     CenterValidations.ifExistCenter(),
     CenterController.updateCenter())
+.get(ValidationService.isValidIntegerURI(),
+     CenterController.getCenter())
+
 
 
 export default centerRouter;


### PR DESCRIPTION
## What does this PR do?
Add functionality for users to get details of a center

## Description of Task to be completed?
Have the following endpoint working

- GET: /api/v1/centers/:centerId

## How should this be manually tested?

Cloning the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route

### Required fields

N/A

## What are the relevant pivotal tracker stories?
#152800576

## Sample screenshot
![get-center](https://user-images.githubusercontent.com/29798373/33089861-41282580-cef2-11e7-9a20-8844d7fb65c6.png)
