### PR TITLE
fix bug in get all centers route

### DIFF
--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -62,8 +62,7 @@ class CenterController extends ModelService {
      * @memberof CenterController
      * @returns {function} A middleware function that handles the GET request
      */
-    static getCenters()
-    {
+    static getCenters() {
         return (req, res) => {
             return this.findAllModelObjects(Center, {
                 order: [['name', 'ASC']],
@@ -86,8 +85,7 @@ class CenterController extends ModelService {
      * @memberof CenterController
      * @returns {function} A middleware function that handles the GET request
      */
-    static getCenter()
-    {
+    static getCenter() {
         return (req, res) => {
             return this.findAllModelObjects(Center, {
                 where: { centerId: req.params.centerId }

--- a/server/routes/centerRoutes.js
+++ b/server/routes/centerRoutes.js
@@ -9,8 +9,8 @@ const { CenterController, UserController } = controllers,
       centerRouter = express.Router();
 
 centerRouter.route('/api/v1/centers')
-.all(UserController.validateUserAccess())
-.post(UserController.checkPrivilege(),
+.post(UserController.validateUserAccess(),
+    UserController.checkPrivilege(),
     CenterValidations.validateCenter(),
     CenterValidations.ifExistCenter(),
     CenterController.createCenter())


### PR DESCRIPTION
## What does this PR do?

Fix bug in get all centers route to allow no authenticated users to get all centers

## Description of Task to be completed?

Have the following endpoint working
- GET: /api/v1/centers

## How should this be manually tested?
Cloning the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route
### Required fields

N/A


## What are the relevant pivotal tracker stories?

#153066623