### PR TITLE
add delete event route

### DIFF
--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -36,8 +36,8 @@ class EventController extends ModelService {
 
     /**
      * @description Gets a single event
-     * @method getEvent
      * @static
+     * @method getEvent
      * @memberof EventController
      * @returns {function} A middleware function that handles the GET request
      */
@@ -55,6 +55,30 @@ class EventController extends ModelService {
             })
             .then((event) => {
                 this.successResponse(res, {event: event});
+            })
+            .catch(error => {
+                this.errorResponse(res, error);
+            })
+        }
+    }
+
+    /**
+     * @description Deletes a event
+     * @static
+     * @method deleteEvent
+     * @memberof EventController
+     * @returns {Function} A middleware funtion that handlses the DELETE request
+     */
+    static deleteEvent() {
+        return (req, res) => {
+            return this.deleteModelObject(Event, {
+                where: {
+                    eventId: req.params.eventId,
+                    userId: req.body.user.userId
+                }
+            })
+            .then((result) => {
+                this.successResponse(res, result);
             })
             .catch(error => {
                 this.errorResponse(res, error);

--- a/server/routes/eventRoutes.js
+++ b/server/routes/eventRoutes.js
@@ -15,8 +15,10 @@ eventRouter.route('/api/v1/events')
     EventController.createEvent())
 
 eventRouter.route('/api/v1/events/:eventId')
-.all(UserController.validateUserAccess())
+.all(UserController.validateUserAccess(),
+    ValidationService.isValidIntegerURI())
 .get(EventController.getEvent())
+.delete(EventController.deleteEvent())
 
 
 


### PR DESCRIPTION
## What does this PR do?

Add functionality for users to delete an event

## Description of Task to be completed?
Have the following endpoint working

- DELETE:  /api/v1/events/:eventId


## How should this be manually tested?
Clone the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route
### Required fields
N/A


## What are the relevant pivotal tracker stories?
 #152800328

## Sample screenshot
![delete-event](https://user-images.githubusercontent.com/29798373/33105569-04f9cbd6-cf2e-11e7-81f4-65f8f00c3a7d.png)
