### PR TITLE
add get all user's event route

### DIFF
--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -39,11 +39,12 @@ class EventController extends ModelService {
     }
 
     /**
-     * @description Gets a single event
+     * @description Gets a single event belonging to a particular user
      * @static
      * @method getEvent
      * @memberof EventController
      * @returns {function} An express middleware function that handles the GET request
+     * @see getEvents()
      */
     static getEvent() {
         return (req, res) => {
@@ -56,6 +57,29 @@ class EventController extends ModelService {
             })
             .then((event) => {
                 this.successResponse(res, {event: event});
+            })
+            .catch(error => {
+                this.errorResponse(res, error);
+            })
+        }
+    }
+
+    /**
+     * @description Gets all events belonging to a particular user
+     * @static
+     * @method getEvents
+     * @memberof EventController
+     * @returns {function} An express middleware function that handles the GET request
+     * @see getEvent()
+     */
+    static getEvents() {
+        return (req, res) => {
+            return this.findAllModelObjects(Event, {
+                where: { userId: req.body.user.userId },
+                include: include
+            })
+            .then((events) => {
+                this.successResponse(res, {events: events});
             })
             .catch(error => {
                 this.errorResponse(res, error);

--- a/server/routes/eventRoutes.js
+++ b/server/routes/eventRoutes.js
@@ -9,11 +9,12 @@ const { EventController, UserController, CenterController } = controllers,
       eventRouter = express.Router();
 
 eventRouter.route('/api/v1/events')
-.post(UserController.validateUserAccess(),
-    EventValidations.validateEvent(),
+.all(UserController.validateUserAccess())
+.post(EventValidations.validateEvent(),
     EventValidations.isExistEvent(),
     CenterController.vaildateCapacity(),
     EventController.createEvent())
+.get(EventController.getEvents())
 
 eventRouter.route('/api/v1/events/:eventId')
 .all(UserController.validateUserAccess(),


### PR DESCRIPTION
## What does this PR do?

Add functionality for users to get all events he or she added

## Description of Task to be completed?
Have the following endpoint working

- GET: /api/v1/events

## How should this be manually tested?

Clone the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route
### Required fields

N/A

## What are the relevant pivotal tracker stories?
#153090955

## Sample screenshot
![get-all-events](https://user-images.githubusercontent.com/29798373/33130241-f61bb1b4-cf92-11e7-98a3-0aefe5f1ae17.png)
