### PR TITLE
add search by name and/or location mechanism

### DIFF
--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -56,7 +56,7 @@ class EventController extends ModelService {
                 include: include
             })
             .then((event) => {
-                this.successResponse(res, {event: event});
+                this.successResponse(res, {event: event}, 302);
             })
             .catch(error => {
                 this.errorResponse(res, error);
@@ -76,10 +76,12 @@ class EventController extends ModelService {
         return (req, res) => {
             return this.findAllModelObjects(Event, {
                 where: { userId: req.body.user.userId },
-                include: include
+                include: include,
+                offset: req.query.page || 0,
+                limit: 10                
             })
             .then((events) => {
-                this.successResponse(res, {events: events});
+                this.successResponse(res, {events: events}, 302);
             })
             .catch(error => {
                 this.errorResponse(res, error);

--- a/server/routes/centerRoutes.js
+++ b/server/routes/centerRoutes.js
@@ -14,7 +14,9 @@ centerRouter.route('/api/v1/centers')
     CenterValidations.validateCenter(),
     CenterValidations.ifExistCenter(),
     CenterController.createCenter())
-.get(CenterController.getCenters())
+.get(CenterController.searchCenters(), 
+    CenterController.getCenters()
+)
 
 centerRouter.route('/api/v1/centers/:centerId')
 .put(UserController.validateUserAccess(),


### PR DESCRIPTION
## What does this PR do?

Add functionality for users to perform a search for centers operation

## Description of Task to be completed?
Have the following endpoint working

- GET: /api/v1/centers?name=value
- GET: /api/v1/centers?location=value
- GET: /api/centers/name=value&location=value


## How should this be manually tested?
Clone the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above routes
### Required fields

N/A

## What are the relevant pivotal tracker stories?
#153092057

## Sample screenshot
![search](https://user-images.githubusercontent.com/29798373/33140257-be148558-cfaf-11e7-9bb0-7d0329ed7264.png)
