### PR TITLE
add view booked date functionality

### DIFF
--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -170,13 +170,13 @@ class CenterController extends ModelService {
                     attributes: ['name'],
                     include: [{
                         model: Event,
-                        where: { approval: req.query.approval },
+                        where: {approval: req.query.approval || false },
                         attributes: ['title', 'date', 'time', 'approval']
                     }]
                 })
                 .then((center) => {
                     this.successResponse(res, {
-                        message: 'Booked dates',
+                        message: ((req.query.approval.toString() === 'true') ? 'Booked' : 'Proposed')+ ' dates',
                         center
                     }, 302);
                 })

--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -170,13 +170,13 @@ class CenterController extends ModelService {
                     attributes: ['name'],
                     include: [{
                         model: Event,
-                        where: {approval: req.query.approval || false },
+                        where: { approval: req.query.approval },
                         attributes: ['title', 'date', 'time', 'approval']
                     }]
                 })
                 .then((center) => {
                     this.successResponse(res, {
-                        message: ((req.query.approval.toString() === 'true') ? 'Booked' : 'Available')+ ' dates',
+                        message: 'Booked dates',
                         center
                     }, 302);
                 })

--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -82,7 +82,7 @@ class CenterController extends ModelService {
                 this.successResponse(res, {centers: centers}, 302);
             })
             .catch(error => {
-                this.errorResponse(res, error);
+                return next(error)//this.errorResponse(res, error);
             })
         }
     }
@@ -145,6 +145,40 @@ class CenterController extends ModelService {
                 })
                 .then((centers) => {
                     this.successResponse(res, {centers: centers}, 302);
+                })
+                .catch(error => {
+                    this.errorResponse(res, error);
+                })
+            }
+        }
+    }
+
+    /**
+     * @description Gets all date booked
+     * @static
+     * @method getBookedDate
+     * @memberof CenterController
+     * @return {function} A middleware function that handles the GET request 
+     */
+    static getBookings() {
+        return (req, res, next) => {
+            if(!req.query.approval)
+                return next();
+            else {
+                return this.findAllModelObjects(Center, {
+                    where: { centerId: req.params.centerId},
+                    attributes: ['name'],
+                    include: [{
+                        model: Event,
+                        where: {approval: req.query.approval || false },
+                        attributes: ['title', 'date', 'time', 'approval']
+                    }]
+                })
+                .then((center) => {
+                    this.successResponse(res, {
+                        message: ((req.query.approval.toString() === 'true') ? 'Booked' : 'Available')+ ' dates',
+                        center
+                    }, 302);
                 })
                 .catch(error => {
                     this.errorResponse(res, error);
@@ -234,6 +268,42 @@ class CenterController extends ModelService {
                 })
 
             } else return next();
+        }
+    }
+
+    /**
+     * @description Checks if an event center is available for a particular date
+     * @method isCenterAvailable
+     * @static
+     * @memberof CenterController
+     * @returns {function} An express middleware function that handles the validaion
+     */
+    static isCenterAvailable() {
+        return (req, res, next) => {
+            let validate = true;
+
+            if (req.method === 'PUT' && !req.body.date)
+                validate = false;
+
+            if (validate) {
+            //     return this.findOneModelObject(, {
+            //         where: { centerId: req.body.centerId },
+            //         attributes: ['availability']
+            //     })
+            //     .then((center) => {
+            //         if(center.availability)
+            //             return next();
+            //         else {
+            //             const error = new Error();
+            //             error.message = `Sorry, ${Center.name.toLowerCase()} has been booked for this date`;
+            //             throw error;
+            //         }
+            //     })
+            //     .catch(error => {
+            //         this.errorResponse(res, error);
+            //     })
+            }
+            else return next();
         }
     }
 }

--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -56,7 +56,7 @@ class EventController extends ModelService {
                 include: include
             })
             .then((event) => {
-                this.successResponse(res, {event: event}, 302);
+                this.successResponse(res, {event: event});
             })
             .catch(error => {
                 this.errorResponse(res, error);
@@ -76,18 +76,17 @@ class EventController extends ModelService {
         return (req, res) => {
             return this.findAllModelObjects(Event, {
                 where: { userId: req.body.user.userId },
-                include: include,
-                offset: req.query.page || 0,
-                limit: 10                
+                include: include
             })
             .then((events) => {
-                this.successResponse(res, {events: events}, 302);
+                this.successResponse(res, {events: events});
             })
             .catch(error => {
                 this.errorResponse(res, error);
             })
         }
     }
+
 
     /**
      * @description Updates an event details

--- a/server/migrations/20171121185750-create-event.js
+++ b/server/migrations/20171121185750-create-event.js
@@ -47,7 +47,11 @@ module.exports = {
                 },
                 onDelete: 'CASCADE',
                 onUpdate: 'CASCADE'
-            },          
+            }, 
+            approval: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+            },         
             createdAt: {
                 allowNull: false,
                 type: Sequelize.DATE

--- a/server/models/center.js
+++ b/server/models/center.js
@@ -108,10 +108,6 @@ export default (sequelize, DataTypes) => {
             allowNull: false,
             defaultValue: true,
             validate: {
-                notEmpty: {
-                    args: true,
-                    msg: 'Availability cannot be empty!'
-                },
                 isBool: (value) => {
                     if(!ValidationService.isBoolean(value)) {
                         error.message = 'Please, enter true or false for availability';

--- a/server/models/event.js
+++ b/server/models/event.js
@@ -79,6 +79,19 @@ module.exports = (sequelize, DataTypes) => {
                 }
             }
         },
+        approval: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            defaultValue: false,
+            validate: {
+                isBool: (value) => {
+                    if(!ValidationService.isBoolean(value)) {
+                        error.message = 'Please, enter true or false for approval';
+                        throw error;
+                    }
+                },
+            },            
+        },
         centerId: {
             type: DataTypes.INTEGER,
             allowNull: false,

--- a/server/routes/centerRoutes.js
+++ b/server/routes/centerRoutes.js
@@ -25,7 +25,9 @@ centerRouter.route('/api/v1/centers/:centerId')
     CenterValidations.ifExistCenter(),
     CenterController.updateCenter())
 .get(ValidationService.isValidIntegerURI(),
-     CenterController.getCenter())
+    CenterController.getBookings(),
+    CenterController.getCenter()
+)
 
 
 

--- a/server/seeders/20171122213113-Center-seeders.js
+++ b/server/seeders/20171122213113-Center-seeders.js
@@ -1,0 +1,43 @@
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.bulkInsert('Centers', [{
+            name: 'A.b. auditorium',
+            capacity: 1500,
+            price: '200,000',
+            location: 'Lagos',
+            address: '16, Ikorodu Road, Ilupeju',
+            description: 'Cool spot for the best celebration',
+            availability: false,
+            userId: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()        
+        }, {
+            name: 'Royal Crown Event Center',
+            capacity: 1500,
+            price: '150,000',
+            location: 'Ilorin',
+            address: '132, Alhaji sambo way, Gupura',
+            availability: false,
+            description: 'Nice place',
+            userId: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()            
+        }, {
+            name: 'Open Space Event Center',
+            capacity: 1500,
+            price: '100,000',
+            location: 'Ogun',
+            address: '132, Opeyemi Road, Ogunabali',
+            availability: false,
+            description: 'Nice place',
+            userId: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        }], {});
+    },
+
+    down: (queryInterface, Sequelize) => {
+        return queryInterface.bulkDelete('Centers', null, {});
+    }
+};

--- a/server/seeders/20171122213136-Event-seeders.js
+++ b/server/seeders/20171122213136-Event-seeders.js
@@ -1,0 +1,58 @@
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.bulkInsert('Events', [{
+            title: 'Emmanuel\'s Birthday Bash',
+            centerId: 1,
+            date: '17/12/2017',
+            time: '12:00 PM', 
+            estimatedGuests: 70,
+            description: 'Class All-white Gallore',
+            approval: false,
+            userId: 2,
+            centerId: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        }, {
+            title: 'Fellows Night',
+            centerId: 1,
+            date: '27/12/2017',
+            time: '12:00 PM', 
+            estimatedGuests: 70,
+            description: 'Classic',
+            approval: true,
+            userId: 2,
+            centerId: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        }, {
+            title: 'Ikenna\'s Bachelor\'s Eve Party',
+            centerId: 1,
+            date: '23/12/2017',
+            time: '12:00 PM', 
+            estimatedGuests: 70,
+            description: 'Class Evening',
+            approval: false,
+            userId: 3,
+            centerId: 2,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        }, {
+            title: 'Celebrate With Jedidiah',
+            centerId: 1,
+            date: '1/1/2018',
+            time: '12:00 PM', 
+            estimatedGuests: 70,
+            description: 'Night of Bliss',
+            approval: true,
+            userId: 2,
+            centerId: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        }], {});
+    },
+
+    down: (queryInterface, Sequelize) => {
+        return queryInterface.bulkDelete('Events', null, {});
+    }
+};


### PR DESCRIPTION
## What does this PR do?
Add the following:
 - functionality that allows users to view booked dates of a particular center, 
- functionality that allows users to view all proposed but not yet approved date of a particular center

## Description of Task to be completed?
Have the following endpoint working

- /api/v1/centers/:centerId/?approval=option

## How should this be manually tested?
Clone the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route
### Required fields

N/A

## What are the relevant pivotal tracker stories?

#152803538

## Sample screenshot
![view-booked-date](https://user-images.githubusercontent.com/29798373/33153204-09312542-cfe1-11e7-912a-3dc4fcaaf5d1.png)
