### PR TITLE
add update center availability and event approval by admin

### DIFF
--- a/server/models/event.js
+++ b/server/models/event.js
@@ -80,7 +80,7 @@ module.exports = (sequelize, DataTypes) => {
             }
         },
         approval: {
-            type: DataTypes.STRING,
+            type: DataTypes.BOOLEAN,
             allowNull: false,
             defaultValue: false,
             validate: {

--- a/server/routes/eventRoutes.js
+++ b/server/routes/eventRoutes.js
@@ -13,6 +13,7 @@ eventRouter.route('/api/v1/events')
 .post(EventValidations.validateEvent(),
     EventValidations.isExistEvent(),
     CenterController.vaildateCapacity(),
+    CenterController.isCenterAvailable(),
     EventController.createEvent())
 .get(EventController.getEvents())
 
@@ -24,6 +25,7 @@ eventRouter.route('/api/v1/events/:eventId')
 .put(EventValidations.validateEvent(),
     CenterController.isValidCenter(),
     CenterController.vaildateCapacity(),
+    CenterController.isCenterAvailable(),
     EventController.updateEvent())
 
 


### PR DESCRIPTION
## What does this PR do?

- Add functionality for admin to update the availability of a center
- Add functionality for admin to approve or cancel an event

## Description of Task to be completed?
Have the following endpoint working

- PUT: /api/v1/centers/:centerId 

## How should this be manually tested?
Cloning the repo
Setup up your environment variables as follows:
    DB_USERNAME = your database username
    DB_NAME = your database name
    DB_PASSWORD = your password
    DB_HOST = localhost
    DB_DIALECT = postgres

then, run the following commands:

- npm install
- npm run migrate:dev
- npm run start:dev

finally, launch Postman and navigate to the above route
### Required fields

N/A

## What are the relevant pivotal tracker stories?

#153119826

## Sample screenshot
![availability](https://user-images.githubusercontent.com/29798373/33187642-7aae500c-d093-11e7-9bdf-6c14fc938faa.png)
